### PR TITLE
Fix i18n strings in contact component

### DIFF
--- a/src/app/components/contact/contact.component.html
+++ b/src/app/components/contact/contact.component.html
@@ -12,29 +12,29 @@
       <!-- Nome -->
       <div class="label-group">
         <label for="name">{{ 'CONTACT.YOUR_NAME' | translate }}</label>
-        <span class="error" *ngIf="errors.name">Nome obrigatório.</span>
+        <span class="error" *ngIf="errors.name">{{ 'CONTACT.NAME_REQUIRED' | translate }}</span>
       </div>
       <input type="text" id="name" [(ngModel)]="name" name="name">
 
       <!-- Email -->
       <div class="label-group">
         <label for="email">{{ 'CONTACT.YOUR_EMAIL' | translate }}</label>
-        <span class="error" *ngIf="errors.email">E-mail obrigatório.</span>
-        <span class="error" *ngIf="errors.invalidEmail">E-mail inválido.</span>
+        <span class="error" *ngIf="errors.email">{{ 'CONTACT.EMAIL_REQUIRED' | translate }}</span>
+        <span class="error" *ngIf="errors.invalidEmail">{{ 'CONTACT.EMAIL_INVALID' | translate }}</span>
       </div>
       <input type="email" id="email" [(ngModel)]="email" name="email">
 
       <!-- Título -->
       <div class="label-group">
         <label for="title">{{ 'CONTACT.EMAIL_TITLE' | translate }}</label>
-        <span class="error" *ngIf="errors.title">Título obrigatório.</span>
+        <span class="error" *ngIf="errors.title">{{ 'CONTACT.TITLE_REQUIRED' | translate }}</span>
       </div>
       <input type="text" id="title" [(ngModel)]="title" name="title">
 
       <!-- Mensagem -->
       <div class="label-group">
         <label for="text">{{ 'CONTACT.EMAIL_SUBJECT' | translate }}</label>
-        <span class="error" *ngIf="errors.text">Mensagem obrigatória.</span>
+        <span class="error" *ngIf="errors.text">{{ 'CONTACT.TEXT_REQUIRED' | translate }}</span>
       </div>
       <textarea id="text" [(ngModel)]="text" name="text"></textarea>
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -9,7 +9,12 @@
     "SEND_EMAIL": "Send",
     "YOUR_NAME": "Your name",
     "EMAIL_SENT_SUCCESS": "Email sent! Oh Yeah!",
-    "EMAIL_SENT_ERROR": "Email wasn't sent, shit happens!"
+    "EMAIL_SENT_ERROR": "Email wasn't sent, shit happens!",
+    "NAME_REQUIRED": "Name required",
+    "EMAIL_REQUIRED": "Email required",
+    "EMAIL_INVALID": "Invalid email",
+    "TITLE_REQUIRED": "Title required",
+    "TEXT_REQUIRED": "Message required"
   },
   "DISCOGRAPHY": "Discography",
   "TOUR": {

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -9,7 +9,12 @@
     "SEND_EMAIL": "Enviar",
     "YOUR_NAME": "Seu nome",
     "EMAIL_SENT_SUCCESS": "E-mail enviado! Oh Yeah!",
-    "EMAIL_SENT_ERROR": "E-mail não enviado, deu alguma merda ai"
+    "EMAIL_SENT_ERROR": "E-mail não enviado, deu alguma merda ai",
+    "NAME_REQUIRED": "Nome obrigatório.",
+    "EMAIL_REQUIRED": "E-mail obrigatório.",
+    "EMAIL_INVALID": "E-mail inválido.",
+    "TITLE_REQUIRED": "Título obrigatório.",
+    "TEXT_REQUIRED": "Mensagem obrigatória."
   },
   "DISCOGRAPHY": "Discografia",
   "TOUR": {


### PR DESCRIPTION
## Summary
- add missing translation keys for contact form errors
- switch hardcoded error strings to i18n

## Testing
- `npm run test:apis`
- `npm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6864d5c54ad8832da48d443e0bedee3d